### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
 Pillow
 numpy
-collections
+collection
 matplotlib


### PR DESCRIPTION
`collections` is no longer a pip package and throws an error when installing `requirements.txt`